### PR TITLE
Allow `info` to be expanded in artifacts list endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea
+
 *.pyc
 *.debug
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+venv
 
 *.pyc
 *.debug

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.12-alpine
+
+RUN apk update &&\
+    apk add --no-cache \
+        bash \
+        ca-certificates \
+        git \
+        sudo \
+        wget
+
+# Install watchmedo for code reloading
+RUN pip install watchdog==5.0.3
+
+WORKDIR /app
+
+# Install python dependencies
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+COPY extra.txt .
+RUN pip install -r extra.txt
+
+# Get working directory properly filled up
+COPY src /src

--- a/dev/compose.yaml
+++ b/dev/compose.yaml
@@ -1,0 +1,28 @@
+name: repos
+services:
+  web:
+    restart: unless-stopped
+    image: repos/web
+    build:
+      context: ..
+      dockerfile: ./dev/Dockerfile
+    command: watchmedo auto-restart --patterns="*.py" --recursive python src/repos/main.py
+    networks:
+      - platforme-dev-network
+    volumes:
+      - ${PLATFORME_REPOS_PATH}:/app
+    ports:
+      - "8085:8080"
+    environment:
+      - LEVEL=INFO
+      - MONGOHQ_URL=mongodb://ripe-core-db-1
+      - BASE_URL=http://localhost:8080
+      - HOST=0.0.0.0
+      - PORT=8080
+
+volumes:
+  mongodb-data:
+
+networks:
+  platforme-dev-network:
+    external: true

--- a/src/repos/models/artifact.py
+++ b/src/repos/models/artifact.py
@@ -75,7 +75,7 @@ class Artifact(appier_extras.admin.Base):
 
     info = appier.field(
         type = dict,
-        private = True,
+        private = False,
         observations = """Special dictionary that contain meta-information
         about the artifact"""
     )


### PR DESCRIPTION
### Issue

- relates with https://github.com/ripe-tech/platforme-realtime/issues/3673
- The goal is to allow `info` data to be fetched when listing artifacts

### Decisions

- The solution we came up with meant to avoid having to call `packages/<name>/info` for all the artifacts we need info from
  - This is especially bad when we need to handle hundreds of artifacts (which we do 😩);
  - Although this ☝️ should be solved (or at least mitigated) by handling artifacts by pages, it still doesn't cover the fact that we'd still be doing N+1 requests (as we'd still need to call the `/info` endpoint);
- Allowing `info` data to be included in the artifacts list is the only way to avoid the N+1;
  - Although we'll be going to request more data from the db all at once (`info` wasn't fetched before), the hypothesis is that one big query vs N+1 small ones won't be that different.

To achieve our goal, the strategy was to mark the `info` field as `private=False`, and manipulate the query result in the controller.
We've tried to avoid this manual work by using different combinations of the `fields`, `rules`, and `fill` parameters of `appier.Model.find`, but there doesn't seem to be any solution that avoids breaking changes in the API without still having to manipulate the query result _ad-hoc_.

Also added a `dev` folder with the necessary files to run the service with docker compose in development, similar to what we have for other internal services in PlatformE.