### PR TITLE
Allow custom sorting in artifacts list

### DIFF
--- a/src/repos/controllers/package.py
+++ b/src/repos/controllers/package.py
@@ -104,13 +104,16 @@ class PackageController(appier.Controller):
     @appier.route("/packages/<str:name>/artifacts", "GET", json=True)
     def artifacts(self, name):
         self.ensure_auth()
+        object_ = appier.get_object(alias=True, find=True)
+
+        # Handle sorting
+        if "sort" not in object_:
+            object_["sort"] = [("timestamp", -1)]
 
         # Perform the find query
-        object_ = appier.get_object(alias=True, find=True)
         artifacts = repos.Artifact.find(
             package=name,
             map=True,
-            sort=[("timestamp", -1)],
             **object_
         )
 


### PR DESCRIPTION
### Issue
- closes itself

### Dependencies
- #1 

### Decisions
We were explicitly sending the sort as a kwarg to `appier.Model.find` , which caused the method to explode if a sort query parameter was received (as there'd be 2 kwargs with the same name).

The changes made allow a custom `sort` query parameter to be sent (e.g.: `sort=timestamp:descending`).